### PR TITLE
Handle Fink livestreams

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,8 @@ setup(
     install_requires=[
         'tomtoolkit>=2.7,<2.10',
         'elasticsearch-dsl>=7.3,<7.5',
-        'markdown'
+        'markdown',
+        'fink-client'
     ],
     extras_require={
         'test': ['factory_boy>=3.1,<3.3']


### PR DESCRIPTION
This PR adds new classes to manipulate Fink livestreams (in addition to data coming from the  REST API):
- [ ] add a Query form (`FinkDESCQueryForm`)
- [ ] add a class to handle livestream (`FinkDESC`)
- [ ] add a method to fetch alerts using the fink-client consumer `FinkDESC.fetch_alerts`
- [ ] add a method to translate data for TOM `FinkDESC.to_generic_alert`
- [ ] update the test suite
- [ ] TBC...
