### PR TITLE
Clean date function for TargetExtra

### DIFF
--- a/tom_fink/fink.py
+++ b/tom_fink/fink.py
@@ -307,6 +307,8 @@ class FinkBroker(GenericBroker):
 
         r.raise_for_status()
         data = r.json()
+        for d in data:
+            d = self._clean_date(d)
 
         return iter(data)
 
@@ -332,7 +334,13 @@ class FinkBroker(GenericBroker):
         )
         r.raise_for_status()
         data = r.json()
+        data = self._clean_date(data)
         return data
+
+    def _clean_date(self, parameters):
+        parameters['v:firstdate'] += ' UTC'
+        parameters['v:lastdate'] += ' UTC'
+        return parameters
 
     def process_reduced_data(self, target, alert=None):
         pass

--- a/tom_fink/tests/tests.py
+++ b/tom_fink/tests/tests.py
@@ -2,7 +2,7 @@ from django.test import TestCase
 from tom_fink.fink import FinkBroker
 # from tom_fink.fink import FinkQueryForm, FinkBroker
 
-test_alert1 =  {,
+test_alert1 =  {
     "i:candid": 1333145050315015017,
     "i:dec": 36.89327,
     "i:objectId": "ZTF18aaavxvj",

--- a/tom_fink/tests/tests.py
+++ b/tom_fink/tests/tests.py
@@ -1,7 +1,30 @@
 from django.test import TestCase
-
+from tom_fink.fink import FinkBroker
 # from tom_fink.fink import FinkQueryForm, FinkBroker
 
+test_alert1 =  {
+    "d:cdsxmatch": "RRLyr",
+    "i:candid": 1333145050315015017,
+    "i:dec": 36.89327,
+    "i:objectId": "ZTF18aaavxvj",
+    "i:publisher": "Fink",
+    "i:ra": 273.8834457,
+    "v:classification": "RRLyr",
+    "v:lastdate": "2020-08-26 03:28:53.003",
+    "v:firstdate": "2018-02-07 12:46:49.996",
+ }
+
+test_alert2 =  {
+    "d:cdsxmatch": "RRLyr",
+    "i:candid": 1333145050315015017,
+    "i:dec": 36.89327,
+    "i:objectId": "ZTF18aaavxvj",
+    "i:publisher": "Fink",
+    "i:ra": 273.8834457,
+    "v:classification": "RRLyr",
+    "v:lastdate": "2020-08-26 03:28:53.003 UTC",
+    "v:firstdate": "2018-02-07 12:46:49.996 UTC",
+ }
 
 class TestFinkQueryForm(TestCase):
     """
@@ -15,8 +38,19 @@ class TestFinkQueryForm(TestCase):
         self.assertTrue(True)
 
 
+
+
 class TestFinkBrokerClass(TestCase):
     """NOTE: To run these tests in your venv: python ./tom_fink/tests/run_tests.py"""
 
     def setUp(self):
-        pass
+        self.test_data = test_alert1
+        self.expected_alert = test_alert2
+
+    def test_clean_date(self):
+        test_alert = self.test_data
+        new_alert = FinkBroker()._clean_date(self, test_alert)
+        self.assertEqual(test_alert, new_alert)
+
+
+

--- a/tom_fink/tests/tests.py
+++ b/tom_fink/tests/tests.py
@@ -2,8 +2,7 @@ from django.test import TestCase
 from tom_fink.fink import FinkBroker
 # from tom_fink.fink import FinkQueryForm, FinkBroker
 
-test_alert1 =  {
-    "d:cdsxmatch": "RRLyr",
+test_alert1 =  {,
     "i:candid": 1333145050315015017,
     "i:dec": 36.89327,
     "i:objectId": "ZTF18aaavxvj",
@@ -15,7 +14,6 @@ test_alert1 =  {
  }
 
 test_alert2 =  {
-    "d:cdsxmatch": "RRLyr",
     "i:candid": 1333145050315015017,
     "i:dec": 36.89327,
     "i:objectId": "ZTF18aaavxvj",


### PR DESCRIPTION
I noticed that if you wanted to save the contents of an alert into a bunch of TargetExtra objects to keep track of the parameters, the TargetExtra class would throw a RuntimeWarning

`/home/bmills/bmillsWork/tom_test/new_venv/lib/python3.9/site-packages/django/db/models/fields/__init__.py:1534: RuntimeWarning:`
`DateTimeField TargetExtra.time_value received a naive datetime (2018-07-07 08:25:56.001000) while time zone support is active.`
 This was because TargetExtra casts the date as a datetime but it is common for django projects to require timezone information. This was fixed by adding a `clean_date()` method that just appends `' UTC'` to the end of the firstdate and lastdate.  I also wrote a small testing function to verify this.