### PR TITLE
Add fix and canary unit test for Issue #98 (sso search produces 500 Server Error)

### DIFF
--- a/tom_fink/fink.py
+++ b/tom_fink/fink.py
@@ -27,6 +27,7 @@ from astropy.time import Time
 
 FINK_URL = "https://api.fink-portal.org"
 COLUMNS = "i:candid,d:rf_snia_vs_nonia,i:ra,i:dec,i:jd,i:magpsf,i:objectId,d:cdsxmatch"
+SSO_COLUMNS = "i:ssnamenr,i:candid,i:ra,i:dec,i:jd,i:magpsf,i:objectId,d:roid"
 
 
 class FinkQueryForm(GenericQueryForm):
@@ -246,7 +247,7 @@ class FinkBroker(GenericBroker):
         elif len(parameters["ssosearch"].strip()) > 0:
             r = requests.post(
                 FINK_URL + "/api/v1/sso",
-                json={"n_or_d": parameters["ssosearch"].strip(), "columns": COLUMNS},
+                json={"n_or_d": parameters["ssosearch"].strip(), "columns": SSO_COLUMNS},
             )
         else:
             msg = """

--- a/tom_fink/tests/tests_canary.py
+++ b/tom_fink/tests/tests_canary.py
@@ -13,6 +13,7 @@ class TestFinkModuleCanary(TestCase):
     def test_boilerplate(self):
         self.assertTrue(True)
 
+
 @tag('canary')
 class TestFinkModuleSSOCanary(TestCase):
     """Tests for the Solar System Object (SSO) search functionality for Issue #98
@@ -21,16 +22,17 @@ class TestFinkModuleSSOCanary(TestCase):
 
     def setUp(self):
         self.broker = FinkBroker()
-        self.parameters = { "query_name": "29P",
-                            "broker": "Fink",
-                            "objectId": "",
-                            "conesearch": "",
-                            "classsearch": "",
-                            "classsearchdate": "",
-                            "ssosearch": "29P"}
+        self.parameters = {"query_name": "29P",
+                           "broker": "Fink",
+                           "objectId": "",
+                           "conesearch": "",
+                           "classsearch": "",
+                           "classsearchdate": "",
+                           "ssosearch": "29P"}
 
     def test_correctkeys(self):
-        expected_keys = ['i:ssnamenr', 'i:candid', 'i:dec', 'i:jd', 'i:magpsf', 'i:objectId', 'i:ra', 'd:roid', 'sso_name', 'sso_number']
+        expected_keys = ['i:ssnamenr', 'i:candid', 'i:dec', 'i:jd', 'i:magpsf',
+                         'i:objectId', 'i:ra', 'd:roid', 'sso_name', 'sso_number']
         data = self.broker.fetch_alerts(self.parameters)
         with self.assertRaises(StopIteration):
             while True:

--- a/tom_fink/tests/tests_canary.py
+++ b/tom_fink/tests/tests_canary.py
@@ -12,3 +12,28 @@ class TestFinkModuleCanary(TestCase):
 
     def test_boilerplate(self):
         self.assertTrue(True)
+
+@tag('canary')
+class TestFinkModuleSSOCanary(TestCase):
+    """Tests for the Solar System Object (SSO) search functionality for Issue #98
+    https://github.com/TOMToolkit/tom_fink/issues/98
+    NOTE: To run these tests in your venv: python ./tom_fink/tests/run_canary_tests.py"""
+
+    def setUp(self):
+        self.broker = FinkBroker()
+        self.parameters = { "query_name": "29P",
+                            "broker": "Fink",
+                            "objectId": "",
+                            "conesearch": "",
+                            "classsearch": "",
+                            "classsearchdate": "",
+                            "ssosearch": "29P"}
+
+    def test_correctkeys(self):
+        expected_keys = ['i:ssnamenr', 'i:candid', 'i:dec', 'i:jd', 'i:magpsf', 'i:objectId', 'i:ra', 'd:roid', 'sso_name', 'sso_number']
+        data = self.broker.fetch_alerts(self.parameters)
+        with self.assertRaises(StopIteration):
+            while True:
+                alert = next(data)
+                for key in expected_keys:
+                    self.assertTrue(key in alert.keys())


### PR DESCRIPTION
This fixes Issue #98 by defining a new set of `SSO_COLUMNS` including the mandatory (but not documented to be mandatory) `ssnamenr` and the potentially useful `d:roid` variable, which gives a score of potential matches to known MPC objects.
Added canary test but this may only work in my environment; guidance on correct approach sought.